### PR TITLE
downgrade peerDependencies core to 0.0.1

### DIFF
--- a/.changeset/hot-emus-wonder.md
+++ b/.changeset/hot-emus-wonder.md
@@ -1,0 +1,9 @@
+---
+'@solid-auth/auth0': patch
+'@solid-auth/core': patch
+'@solid-auth/credentials': patch
+'@solid-auth/oauth2': patch
+'@solid-auth/socials': patch
+---
+
+downgrade peerDependencies core to 0.0.1

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -37,7 +37,7 @@
     "typescript": "^4.9.3"
   },
   "peerDependencies": {
-    "@solid-auth/core": "^0.0.4",
+    "@solid-auth/core": "^0.0.1",
     "solid-js": "^1.5.7",
     "solid-start": "^0.2.1"
   },

--- a/packages/core/src/strategy.ts
+++ b/packages/core/src/strategy.ts
@@ -158,6 +158,7 @@ export abstract class Strategy<User, VerifyOptions> {
     // in the session sessionKey
     session.set(options.sessionKey, user)
     session.set(options.sessionStrategyKey, options.name ?? this.name)
+    let success = false
     if (user !== null && user !== undefined) {
       if (options.successRedirect) {
         throw redirect(options.successRedirect, {
@@ -167,17 +168,10 @@ export abstract class Strategy<User, VerifyOptions> {
           },
         })
       }
-      throw json(
-        { success: true },
-        {
-          headers: {
-            'Set-Cookie': await sessionStorage.commitSession(session),
-          },
-        }
-      )
+      success = true
     }
     throw json(
-      { success: false },
+      { success },
       {
         headers: {
           'Set-Cookie': await sessionStorage.commitSession(session),

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.9.3"
   },
   "peerDependencies": {
-    "@solid-auth/core": "^0.0.4",
+    "@solid-auth/core": "^0.0.1",
     "solid-js": "^1.5.7",
     "solid-start": "^0.2.1"
   },

--- a/packages/oauth2/package.json
+++ b/packages/oauth2/package.json
@@ -37,7 +37,7 @@
     "typescript": "^4.9.3"
   },
   "peerDependencies": {
-    "@solid-auth/core": "^0.0.4",
+    "@solid-auth/core": "^0.0.1",
     "solid-js": "^1.5.7",
     "solid-start": "^0.2.1"
   },

--- a/packages/socials/package.json
+++ b/packages/socials/package.json
@@ -38,7 +38,7 @@
     "typescript": "^4.9.3"
   },
   "peerDependencies": {
-    "@solid-auth/core": "^0.0.4",
+    "@solid-auth/core": "^0.0.1",
     "solid-js": "^1.5.7",
     "solid-start": "^0.2.1"
   },


### PR DESCRIPTION
- Allow null and undefined to be returned to strategies
- downgrade peerDependencies core to 0.0.1
