### PR TITLE
test onlyUpdatePeerDependentsWhenOutOfRange

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,10 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "onlyUpdatePeerDependentsWhenOutOfRange": true,
+  "___experimentalUnsafeOptions_onlyUpdatePeerDependentsWhenOutOfRange": true,
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": []
 }


### PR DESCRIPTION
- Allow null and undefined to be returned to strategies
- downgrade peerDependencies core to 0.0.1
- test - onlyUpdatePeerDependentsWhenOutOfRange
