### PR TITLE
changest ignore app examples

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,5 +15,5 @@
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   },
-  "ignore": []
+  "ignore": ["prisma-credentials", "prisma-socials"]
 }


### PR DESCRIPTION
- Allow null and undefined to be returned to strategies
- downgrade peerDependencies core to 0.0.1
- test - onlyUpdatePeerDependentsWhenOutOfRange
- changeset ignore app examples
