### PR TITLE
fix(oauth2): replace uuid with web crypto api

### DIFF
--- a/.changeset/curly-penguins-help.md
+++ b/.changeset/curly-penguins-help.md
@@ -1,0 +1,5 @@
+---
+'@solid-auth/oauth2': patch
+---
+
+use Web Crypto Api insetad of the uuid package. Closes [#23](https://github.com/OrJDev/solid-auth/issues/23)

--- a/packages/oauth2/src/index.ts
+++ b/packages/oauth2/src/index.ts
@@ -5,7 +5,6 @@ import {
 } from '@solid-auth/core'
 import type { SessionStorage } from 'solid-start'
 import { json } from 'solid-start'
-import { v4 as uuid } from 'uuid'
 
 export interface OAuth2Profile {
   provider: string
@@ -291,7 +290,7 @@ export class OAuth2Strategy<
   }
 
   private generateState() {
-    return uuid()
+    return crypto.randomUUID()
   }
 
   /**


### PR DESCRIPTION
closed #23

This should fix #23. 
Tested with Node v16, v18 and CF Workers