### PR TITLE
fix(core|oauth2): remove the sessionStateKey from the session after the oauth2 state was verified

### DIFF
--- a/.changeset/neat-months-collect.md
+++ b/.changeset/neat-months-collect.md
@@ -1,0 +1,6 @@
+---
+'@solid-auth/core': patch
+'@solid-auth/oauth2': patch
+---
+
+remove the sessionStateKey from the session after the oauth2 state was verified

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "turbo build",
     "clean": "turbo clean && rm -rf node_modules pnpm-lock.yaml",
     "dev": "turbo dev",
+    "dev:packages": "turbo dev --filter=./packages/*",
     "lint": "eslint . --fix --ext .ts,.tsx,.js,.jsx",
     "prepare": "husky install",
     "www": "cd www && pnpm dev"

--- a/packages/core/src/strategy.ts
+++ b/packages/core/src/strategy.ts
@@ -10,6 +10,10 @@ export interface AuthenticateOptions {
    */
   sessionKey: string
   /**
+   * The key of the session used to set the state during the oauth2 flow.
+   */
+  sessionStateKey?: string
+  /**
    * In what key of the session the errors will be set.
    * @default "auth:error"
    */
@@ -154,6 +158,7 @@ export abstract class Strategy<User, VerifyOptions> {
       request.headers.get('Cookie')
     )
     session.unset('opts')
+    session.unset(options.sessionStateKey)
     // if we do have a successRedirect, we redirect to it and set the user
     // in the session sessionKey
     session.set(options.sessionKey, user)

--- a/packages/oauth2/src/index.ts
+++ b/packages/oauth2/src/index.ts
@@ -134,18 +134,19 @@ export class OAuth2Strategy<
     const session = await sessionStorage.getSession(
       request.headers.get('Cookie')
     )
+
     let user: User | null = session.get(options.sessionKey) ?? null
     // User is already authenticated
     if (user) {
       return this.success(user, request, sessionStorage, options)
     }
 
-    const callbackURL = this.getCallbackURL(url)
     // Redirect the user to the callback URL
+    const callbackURL = this.getCallbackURL(url)
     if (url.pathname !== callbackURL.pathname) {
       const state = this.generateState()
       session.set(this.sessionStateKey, state)
-      session.set('opts', options)
+      session.set('opts', { ...options, sessionStateKey: this.sessionStateKey })
       const reURI = this.getAuthorizationURL(request, state).toString()
       return json(
         { redirect: reURI },


### PR DESCRIPTION
In the oauth2 package a state is set on the session.
This unsets the state in the core package. 

Since this is just a small patch, we can release it when we fixed #31 