### PR TITLE
Skip `getSession` on signIn error

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -165,7 +165,7 @@ export async function signIn<
     return;
   }
   const error = new URL(data.url).searchParams.get("error");
-  if (res.ok) {
+  if (res.ok && !error) {
     await __SOLIDAUTH._getSession({ event: "storage" });
   }
   return {


### PR DESCRIPTION
As mentioned in issue #3 session fetch is triggered even though log in does not go through. This change makes it so session is only fetched when there is no error => avoids unnecessarily falling back to Suspended state

Still haven't figured out a good way to deal with the other issue of Login page flashing, though.